### PR TITLE
Add peer context features to R pipeline

### DIFF
--- a/R/features.R
+++ b/R/features.R
@@ -1,0 +1,75 @@
+# Peer context feature engineering utilities
+
+#' Peer context features
+#'
+#' For each officer, count the number of incidents co-assigned with colleagues
+#' who have recent complaints or uses of force. Optionally compute network
+#' centrality measures (degree and betweenness) on the co-assignment graph.
+#'
+#' @param df Tibble returned by `load_data`. Must include `incident_id`,
+#'   `officer_id`, `event_type`, and `event_datetime`.
+#' @param lookback_days Numeric window defining "recent" in days.
+#' @return Tibble with one row per officer and peer context features.
+build_peer_context_features <- function(df, lookback_days = 90) {
+  incidents <- df %>%
+    filter(event_type == "incident") %>%
+    select(incident_id, officer_id, event_datetime) %>%
+    distinct()
+
+  if (nrow(incidents) == 0) {
+    return(tibble(officer_id = df$officer_id %>% unique()) %>%
+             mutate(co_flagged_complaint = 0,
+                    co_flagged_use_of_force = 0,
+                    peer_degree = 0,
+                    peer_betweenness = 0))
+  }
+
+  flag_events <- df %>%
+    filter(event_type %in% c("complaint", "use_of_force")) %>%
+    select(officer_id, flag_type = event_type, flag_datetime = event_datetime)
+
+  pairs <- incidents %>%
+    rename(officer_id_main = officer_id,
+           incident_datetime = event_datetime) %>%
+    inner_join(incidents, by = "incident_id", suffix = c("_main", "_colleague")) %>%
+    filter(officer_id_main != officer_id_colleague)
+
+  flagged_pairs <- pairs %>%
+    left_join(flag_events, by = c("officer_id_colleague" = "officer_id")) %>%
+    filter(!is.na(flag_datetime),
+           flag_datetime <= incident_datetime,
+           flag_datetime >= incident_datetime - lubridate::days(lookback_days))
+
+  co_flag_counts <- flagged_pairs %>%
+    group_by(officer_id_main, flag_type) %>%
+    summarise(n = n_distinct(incident_id), .groups = "drop") %>%
+    pivot_wider(names_from = flag_type, values_from = n,
+                names_prefix = "co_flagged_", values_fill = 0)
+
+  if (!requireNamespace("igraph", quietly = TRUE) || nrow(pairs) == 0) {
+    centrality <- tibble(officer_id = unique(incidents$officer_id),
+                         peer_degree = 0,
+                         peer_betweenness = 0)
+  } else {
+    edges <- pairs %>%
+      transmute(
+        from = pmin(officer_id_main, officer_id_colleague),
+        to = pmax(officer_id_main, officer_id_colleague)
+      ) %>%
+      distinct()
+
+    g <- igraph::graph_from_data_frame(edges, directed = FALSE)
+
+    centrality <- tibble(
+      officer_id = igraph::V(g)$name,
+      peer_degree = igraph::degree(g),
+      peer_betweenness = igraph::betweenness(g, normalized = TRUE)
+    )
+  }
+
+  incidents %>%
+    distinct(officer_id) %>%
+    left_join(co_flag_counts, by = c("officer_id" = "officer_id_main")) %>%
+    left_join(centrality, by = "officer_id") %>%
+    replace(is.na(.), 0)
+}

--- a/R/pipeline.R
+++ b/R/pipeline.R
@@ -3,6 +3,7 @@
 library(tidyverse)
 library(tidymodels)
 library(fastshap)
+source("R/features.R")
 
 #' Load raw incident data
 #'
@@ -272,9 +273,10 @@ build_features <- function(df) {
   characteristics <- build_characteristics_features(df)
   employment <- build_employment_features(df)
   demographic <- build_demographic_features(df)
+  peer_context <- build_peer_context_features(df)
 
   list(incidents, compliments, shifts, arrests, traffic,
-       characteristics, employment, demographic) %>%
+       characteristics, employment, demographic, peer_context) %>%
     reduce(full_join, by = "officer_id") %>%
     replace(is.na(.), 0)
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ any columns needed for the individual feature blocks (for example
 `suspension_type`, `incident_type`, `shift_type`, `driver_race`, etc.) along with
 an `outcome` flag.
 
+Peer context features additionally require an `incident_id` to link officers
+who respond to the same incident. The data should also include `complaint` and
+`use_of_force` events with dates so that colleagues with recent issues can be
+identified. Network centrality metrics are calculated with the optional
+`igraph` package.
+
 ## How to Run the Pipeline
 The pipeline has two main configurations. In the **modelling** configuration, there are three distinct steps.
 


### PR DESCRIPTION
## Summary
- add `build_peer_context_features()` to derive counts of co-assigned incidents with recently flagged colleagues and optional network centrality
- integrate peer-context features into `build_features()`
- document incident ID and complaint/use-of-force requirements for R pipeline

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'imp' from nose)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ebb6bec8325b2fcb322a2fbfe30